### PR TITLE
Locally set up Meza database

### DIFF
--- a/src/main/java/dev/khwilo/mezapay/config/SecurityConfiguration.java
+++ b/src/main/java/dev/khwilo/mezapay/config/SecurityConfiguration.java
@@ -1,0 +1,19 @@
+package dev.khwilo.mezapay.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class SecurityConfiguration {
+
+  @Bean
+  public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+    http.csrf(AbstractHttpConfigurer::disable)
+        .authorizeHttpRequests((authorize) -> authorize.anyRequest().permitAll());
+
+    return http.build();
+  }
+}

--- a/src/main/java/dev/khwilo/mezapay/test/Country.java
+++ b/src/main/java/dev/khwilo/mezapay/test/Country.java
@@ -1,0 +1,23 @@
+package dev.khwilo.mezapay.test;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@ToString
+@Entity
+@Table(name = "countries")
+public class Country {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.AUTO)
+  @Column(name = "id")
+  private Long id;
+
+  @Column(name = "name")
+  private String name;
+}

--- a/src/main/java/dev/khwilo/mezapay/test/CountryController.java
+++ b/src/main/java/dev/khwilo/mezapay/test/CountryController.java
@@ -1,0 +1,53 @@
+package dev.khwilo.mezapay.test;
+
+import java.util.List;
+import java.util.Optional;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/test")
+public class CountryController {
+
+  private final CountryService countryService;
+
+  public CountryController(CountryService countryService) {
+    this.countryService = countryService;
+  }
+
+  @GetMapping
+  public ResponseEntity<List<Country>> getAll() {
+    List<Country> countries = countryService.getAll();
+    return ResponseEntity.ok(countries);
+  }
+
+  @GetMapping("/{id}")
+  public ResponseEntity<Country> getOne(@PathVariable("id") Long id) {
+    Optional<Country> country = countryService.getOne(id);
+
+    return country.map(ResponseEntity::ok).orElseGet(() -> ResponseEntity.notFound().build());
+  }
+
+  @PostMapping
+  public ResponseEntity<Country> post(@RequestBody CountryDto countryDto) {
+    Country country = countryService.add(countryDto);
+
+    return ResponseEntity.status(HttpStatus.CREATED).body(country);
+  }
+
+  @PutMapping("/{id}")
+  public ResponseEntity<Country> put(
+      @PathVariable("id") Long id, @RequestBody CountryDto countryDto) {
+    Optional<Country> country = countryService.put(id, countryDto);
+
+    return country.map(ResponseEntity::ok).orElseGet(() -> ResponseEntity.notFound().build());
+  }
+
+  @DeleteMapping("/{id}")
+  public ResponseEntity<String> delete(@PathVariable("id") Long id) {
+    countryService.delete(id);
+
+    return ResponseEntity.ok("Successfully deleted country");
+  }
+}

--- a/src/main/java/dev/khwilo/mezapay/test/CountryDto.java
+++ b/src/main/java/dev/khwilo/mezapay/test/CountryDto.java
@@ -1,0 +1,3 @@
+package dev.khwilo.mezapay.test;
+
+public record CountryDto(String name) {}

--- a/src/main/java/dev/khwilo/mezapay/test/CountryRepository.java
+++ b/src/main/java/dev/khwilo/mezapay/test/CountryRepository.java
@@ -1,0 +1,7 @@
+package dev.khwilo.mezapay.test;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CountryRepository extends JpaRepository<Country, Long> {}

--- a/src/main/java/dev/khwilo/mezapay/test/CountryService.java
+++ b/src/main/java/dev/khwilo/mezapay/test/CountryService.java
@@ -1,0 +1,52 @@
+package dev.khwilo.mezapay.test;
+
+import java.util.List;
+import java.util.Optional;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class CountryService {
+
+  private final CountryRepository countryRepository;
+
+  public CountryService(CountryRepository countryRepository) {
+    this.countryRepository = countryRepository;
+  }
+
+  public List<Country> getAll() {
+    return countryRepository.findAll();
+  }
+
+  public Optional<Country> getOne(Long id) {
+
+    return countryRepository.findById(id);
+  }
+
+  @Transactional
+  public Country add(CountryDto countryDto) {
+    Country country = Country.builder().name(countryDto.name()).build();
+    return countryRepository.save(country);
+  }
+
+  @Transactional
+  public Optional<Country> put(Long id, CountryDto countryDto) {
+    Optional<Country> country = countryRepository.findById(id);
+
+    if (country.isPresent()) {
+      country.get().setName(countryDto.name());
+      return country;
+    }
+
+    return Optional.empty();
+  }
+
+  @Transactional
+  public void delete(Long id) {
+    boolean countryPresent = countryRepository.existsById(id);
+
+    if (countryPresent) {
+      countryRepository.deleteById(id);
+    }
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,1 +1,16 @@
+server:
+  port: 8081
+  servlet:
+    context-path: /mezapay
 
+spring:
+  datasource:
+    url: jdbc:postgresql://localhost:5432/meza
+    username: meza
+    password: meza@BNK#2023
+    driver-class-name: org.postgresql.Driver
+  jpa:
+    database-platform: org.hibernate.dialect.PostgreSQLDialect
+    show-sql: true
+    hibernate:
+      ddl-auto: create


### PR DESCRIPTION
## Description

Implement CRUD operations on a database

## Tasks

- [x] Set up PostgreSQL DB locally
- [x] Implement CRUD operation on test data
- [x] Exclude API endpoints temporarily from authentication

## Note

### Setting up DB locally

Execute the following commands from the terminal.

```bash
psql postgres
create role meza with login password 'meza@BNK#2023';
alter role meza createdb;
```

## Issue

Linked issue: https://github.com/mvp-s/mezapay/issues/1